### PR TITLE
Add a nixos configuration module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       imports = [
         inputs.devshell.flakeModule
         inputs.generate-go-sri.flakeModules.default
+        ./nixos/tests/flake-part.nix
       ];
       systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
       perSystem = {
@@ -46,7 +47,7 @@
         };
       };
 
-      flake.nixosModules.default = importApply ./nixos/module.nix {
+      flake.nixosModules.default = import ./nixos/module.nix {
         inherit withSystem;
       };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,13 @@
 {
   outputs = inputs @ {flake-parts, ...}:
-    flake-parts.lib.mkFlake {inherit inputs;} {
+    flake-parts.lib.mkFlake {inherit inputs;} ({
+      flake-parts-lib,
+      self,
+      withSystem,
+      ...
+    }: let
+      inherit (flake-parts-lib) importApply;
+    in {
       imports = [
         inputs.devshell.flakeModule
         inputs.generate-go-sri.flakeModules.default
@@ -38,7 +45,11 @@
           ];
         };
       };
-    };
+
+      flake.nixosModules.default = importApply ./nixos/module.nix {
+        inherit withSystem;
+      };
+    });
 
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -62,12 +62,8 @@
     };
   };
 
-  config = {
-    config,
-    lib,
-    ...
-  }: (let
-    cfg = config.initrd.hoopsnake;
+  config = let
+    cfg = config.boot.initrd.hoopsnake;
   in
     lib.mkIf cfg.enable {
       boot.initrd.network.postCommands = ''
@@ -87,5 +83,5 @@
         "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
         "/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;
       };
-    });
+    };
 }

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -1,0 +1,88 @@
+{withSystem}: {
+  lib,
+  pkgs,
+  config,
+  ...
+}: {
+  options = with lib; {
+    boot.initrd.hoopsnake = let
+      flakePkgs = withSystem ({config, ...}: config.packages);
+    in {
+      enable = mkEnableOption "Enable the hoopsnake SSH server";
+      package = mkPackageOption flakePkgs "hoopsnake" {
+        default = ["inputs.hoopsnake.packages.default"];
+      };
+
+      ssh = {
+        authorizedKeysFile = mkOption {
+          description = "Path to a file listing the authorized public keys that may authenticate to hoopsnake";
+          type = types.nullOr types.path;
+        };
+        privateHostKey = mkOption {
+          description = "Path to a PEM-encoded secret key that the hoopsnake SSH server will use to authenticate itself to clients. This is a secret - it should't live in the nix store.";
+          type = types.path;
+        };
+        shell = mkOption {
+          description = "The shell package to run";
+          default = "${pkgs.busybox}/bin/ash";
+          type = types.oneOf [types.shellPackage types.path];
+        };
+      };
+
+      tailscale = {
+        name = mkOption {
+          description = "Name of the tailscale service that the hoopsnake SSH server runs on.";
+          type = types.str;
+        };
+        tags = mkOption {
+          description = "List of tags to assign the hoopsnake SSH server. At least one is required.";
+          type = types.nonEmptyListOf (types.strMatching "^tag:.+$");
+        };
+        environmentFile = mkOption {
+          description = "Environment file setting TS_AUTHKEY, TS_API_KEY or TS_API_CLIENT_ID & TS_API_CLIENT_SECRET. These are secrets, so shouldn't live in the nix store.";
+          type = types.path;
+        };
+        cleanup = {
+          deleteExisting = mkOption {
+            description = "Whether to delete existing nodes with the configured hoopsnake SSH server's name";
+            default = false;
+            type = types.bool;
+          };
+
+          maxNodeAge = mkOption {
+            description = "Any existing node with this server's name must be offline at least this long to be considered for deletion.";
+            default = "30s";
+            type = types.str;
+          };
+        };
+      };
+    };
+  };
+
+  config = {
+    config,
+    lib,
+    ...
+  }:
+    lib.mkIf cfg.enable (let
+      cfg = config.initrd.hoopsnake;
+    in {
+      boot.initrd.network.postCommands = ''
+        . /etc/hoopsnake/tailscale/environment
+        export TS_AUTHKEY TS_API_KEY TS_API_CLIENT_ID TS_API_CLIENT_SECRET TS_BASE_URL
+
+        ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
+           -tags=${lib.escapeShellArg (lib.concatStringsSep cfg.tailscale.tags ",")} \
+           -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
+           -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
+           -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
+           -hostKey=/etc/hoopsnake/ssh/host_key \
+           ${lib.escapeShellArg cfg.ssh.shell} &
+      '';
+      boot.initrd.secrets = {
+        "/etc/hoopsnake/ssh/host_key" = cfg.ssh.privateHostKey;
+        "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
+        "/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;
+      };
+    });
+}

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -8,12 +8,21 @@
   ...
 }: {
   options = with lib; {
-    boot.initrd.hoopsnake = let
-      flakePkgs = withSystem ({config, ...}: config.packages);
+    boot.initrd.network.hoopsnake = let
+      hoopsnake = withSystem pkgs.stdenv.targetPlatform.system ({config, ...}: config.packages.default);
     in {
       enable = mkEnableOption "Enable the hoopsnake SSH server";
-      package = mkPackageOption flakePkgs "hoopsnake" {
-        default = ["inputs.hoopsnake.packages.default"];
+      package = mkOption {
+        description = "The hoopsnake package";
+        type = types.package;
+        default = hoopsnake;
+        defaultText = lib.literalExpression "inputs.hoopsnake.packages.''${system}.default";
+      };
+
+      includeSSLBundle = mkOption {
+        description = "Whether to include the SSL certificate bundle data in the initrd.";
+        default = true;
+        type = types.bool;
       };
 
       ssh = {
@@ -45,6 +54,8 @@
           description = "Environment file setting TS_AUTHKEY, TS_API_KEY or TS_API_CLIENT_ID & TS_API_CLIENT_SECRET. These are secrets, so shouldn't live in the nix store.";
           type = types.path;
         };
+        tsnetVerbose = mkEnableOption "verbose logging from the tsnet package";
+
         cleanup = {
           deleteExisting = mkOption {
             description = "Whether to delete existing nodes with the configured hoopsnake SSH server's name";
@@ -63,25 +74,35 @@
   };
 
   config = let
-    cfg = config.boot.initrd.hoopsnake;
+    cfg = config.boot.initrd.network.hoopsnake;
   in
     lib.mkIf cfg.enable {
       boot.initrd.network.postCommands = ''
+        echo "Starting hoopsnake..."
         . /etc/hoopsnake/tailscale/environment
         export TS_AUTHKEY TS_API_KEY TS_API_CLIENT_ID TS_API_CLIENT_SECRET TS_BASE_URL
 
         ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
-           -tags=${lib.escapeShellArg (lib.concatStringsSep cfg.tailscale.tags ",")} \
+           -tsnetVerbose=${lib.boolToString cfg.tailscale.tsnetVerbose} \
+           -tags=${lib.escapeShellArg (lib.concatStringsSep "," cfg.tailscale.tags)} \
            -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
            -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
            -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
            -hostKey=/etc/hoopsnake/ssh/host_key \
            ${lib.escapeShellArg cfg.ssh.shell} &
       '';
-      boot.initrd.secrets = {
-        "/etc/hoopsnake/ssh/host_key" = cfg.ssh.privateHostKey;
-        "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
-        "/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;
-      };
+      boot.initrd.secrets = lib.mkMerge [
+        {
+          "/etc/hoopsnake/ssh/host_key" = cfg.ssh.privateHostKey;
+          "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
+          "/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;
+        }
+        (lib.mkIf cfg.includeSSLBundle {
+          "/etc/ssl/ca-bundle.crt" = config.environment.etc."ssl/certs/ca-bundle.crt".source;
+          "/etc/ssl/ca-certificates.crt" = config.environment.etc."ssl/certs/ca-certificates.crt".source;
+          "/etc/pki/tls/certs/ca-bundle.crt" = config.environment.etc."pki/tls/certs/ca-bundle.crt".source;
+          "/etc/ssl/trust-source" = config.environment.etc."ssl/trust-source".source;
+        })
+      ];
     };
 }

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -1,4 +1,7 @@
-{withSystem}: {
+# importApply arguments:
+{withSystem}:
+# Regular NixOS module arguments:
+{
   lib,
   pkgs,
   config,
@@ -63,10 +66,10 @@
     config,
     lib,
     ...
-  }:
-    lib.mkIf cfg.enable (let
-      cfg = config.initrd.hoopsnake;
-    in {
+  }: (let
+    cfg = config.initrd.hoopsnake;
+  in
+    lib.mkIf cfg.enable {
       boot.initrd.network.postCommands = ''
         . /etc/hoopsnake/tailscale/environment
         export TS_AUTHKEY TS_API_KEY TS_API_CLIENT_ID TS_API_CLIENT_SECRET TS_BASE_URL

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -1,8 +1,4 @@
-{
-  self,
-  inputs,
-  ...
-}: {
+{self, ...}: {
   perSystem = {
     config,
     pkgs,
@@ -30,15 +26,17 @@
     envFiles = {
       apiKey = pkgs.writeText "apikey-envfile" ''
         TS_API_KEY=OVehtREWXA._bTQCNek9SsZk5Jy9aIUpGWNWXo61rTh0QTg-_MUCv4
+        TS_BASE_URL=https://headscale
       '';
       authKey = pkgs.writeText "apikey-envfile" ''
         TS_AUTHKEY=e01aa49edded75748e17903330e3f18c25496b47360ffdec
+        TS_BASE_URL=https://headscale
       '';
       # Unfortunately, headscale doesn't support oauth client id/secret yet.
     };
     dbDump = pkgs.writeText "generated_keys.sql" ''
-      INSERT INTO pre_auth_keys VALUES(1,'e01aa49edded75748e17903330e3f18c25496b47360ffdec',1,0,0,0,datetime(),datetime('now','+1 hour'));
-        INSERT INTO api_keys VALUES(1,'OVehtREWXA',X'24326124313024436f72666574456a30774973344c3745616e697234756e2e536c6746654e71527030694448596153594968355a65374f6742513061',datetime(),datetime('now','+1 hour'),NULL);
+      INSERT INTO pre_auth_keys VALUES(90,'e01aa49edded75748e17903330e3f18c25496b47360ffdec',1,0,0,0,datetime(),datetime('now','+1 hour'));
+      INSERT INTO api_keys VALUES(90,'OVehtREWXA',X'24326124313024436f72666574456a30774973344c3745616e697234756e2e536c6746654e71527030694448596153594968355a65374f6742513061',datetime(),datetime('now','+1 hour'),NULL);
     '';
     hostkey = pkgs.runCommand "hostkey" {buildInputs = [pkgs.openssh];} ''
       mkdir $out
@@ -48,16 +46,70 @@
       mkdir $out
       ssh-keygen -N "" -t ed25519 -f $out/client
     '';
-    bootloader = {
+    bootloader = {config, ...}: {
       virtualisation.useBootLoader = true;
       virtualisation.useEFIBoot = true;
       boot.loader.systemd-boot.enable = true;
       boot.loader.efi.canTouchEfiVariables = true;
       environment.systemPackages = [pkgs.efibootmgr];
+      boot.kernelParams = [
+        "ip=${config.networking.primaryIPAddress}:::255.255.255.0::eth1:off"
+      ];
+      boot.initrd.preLVMCommands = ''
+        while true; do
+            if [ -f fnord ]; then
+              poweroff
+            fi
+            echo "Waiting to be told to shutdown"
+            sleep 1
+          done
+      '';
+      boot.initrd.network = {
+        enable = true;
+        udhcpc.enable = false;
+      };
+      boot.initrd.secrets = {
+        "/etc/hosts" = "${config.environment.etc.hosts.source}";
+      };
+      security.pki.certificateFiles = ["${tls-cert}/cert.pem"];
     };
+    headscalePort = 8080;
     stunPort = 3478;
+
     headscale = {config, ...}: {
+      services = {
+        headscale = {
+          enable = true;
+          port = headscalePort;
+          settings = {
+            server_url = "https://headscale";
+            ip_prefixes = ["100.64.0.0/10"];
+            derp.server = {
+              enabled = true;
+              region_id = 999;
+              stun_listen_addr = "0.0.0.0:${toString stunPort}";
+            };
+          };
+        };
+        nginx = {
+          enable = true;
+          virtualHosts.headscale = {
+            addSSL = true;
+            sslCertificate = "${tls-cert}/cert.pem";
+            sslCertificateKey = "${tls-cert}/key.pem";
+            locations."/" = {
+              proxyPass = "http://127.0.0.1:${toString headscalePort}";
+              proxyWebsockets = true;
+            };
+          };
+        };
+      };
+      networking.firewall = {
+        allowedTCPPorts = [80 443];
+        allowedUDPPorts = [stunPort];
+      };
       environment.systemPackages = [
+        pkgs.headscale
         (pkgs.writeShellApplication {
           name = "import-pregenerated-keys";
           runtimeInputs = [pkgs.sqlite];
@@ -65,35 +117,7 @@
             sqlite3 /var/lib/headscale/db.sqlite <${dbDump}
           '';
         })
-        pkgs.headscale
       ];
-      services.headscale = {
-        enable = true;
-        settings = {
-          ip_prefixes = ["100.64.0.0/10"];
-          derp.server = {
-            enabled = true;
-            region_id = 999;
-            stun_listen_addr = "0.0.0.0:${toString stunPort}";
-          };
-        };
-      };
-      networking.firewall = {
-        allowedTCPPorts = [443 80];
-        allowedUDPPorts = [stunPort];
-      };
-      services.nginx = {
-        enable = true;
-        virtualHosts.headscale = {
-          addSSL = true;
-          sslCertificate = "${tls-cert}/cert.pem";
-          sslCertificateKey = "${tls-cert}/key.pem";
-          locations."/" = {
-            proxyPass = "http://127.0.0.1:${toString config.services.headscale.port}";
-            proxyWebsockets = true;
-          };
-        };
-      };
     };
   in {
     checks =
@@ -104,48 +128,47 @@
           name = "hoopsnake-starts";
           nodes = {
             inherit headscale;
+            peer = {
+              services.tailscale.enable = true;
+              security.pki.certificateFiles = ["${tls-cert}/cert.pem"];
+            };
             alice = {...}: {
               imports = [bootloader self.nixosModules.default];
-              boot.initrd.hoopsnake = {
-                enable = true;
-                ssh = {
-                  authorizedKeysFile = "${clientKey}/client.pub";
-                  privateHostKey = "${hostkey}/hostkey";
-                };
-                tailscale = {
-                  name = "alice-boot";
-                  tags = ["tag:hoopsnake"];
-                  environmentFile = envFiles.authKey;
+              boot.initrd.network = {
+                hoopsnake = {
+                  enable = true;
+                  ssh = {
+                    authorizedKeysFile = "${clientKey}/client.pub";
+                    privateHostKey = "${hostkey}/hostkey";
+                  };
+                  tailscale = {
+                    name = "alice-boot";
+                    tags = ["tag:hoopsnake"];
+                    environmentFile = envFiles.authKey;
+                    tsnetVerbose = true;
+                  };
                 };
               };
-            };
-            bob = {
-              services.tailscale.enable = true;
-              systemd.services.tailscaled.serviceConfig.Environment = ["TS_NO_LOGS_NO_SUPPORT=true"];
-              security.pki.certificateFiles = ["${tls-cert}/cert.pem"];
             };
           };
 
           testScript = ''
-            headscale.start()
-            bob.start()
+            for node in [headscale, peer]:
+                node.start()
             headscale.wait_for_unit("headscale")
-            headscale.succeed("headscale users create alice")
+            headscale.wait_for_open_port(443)
+
+            # Create headscale user and preauth-key
+            headscale.succeed("headscale users create peer")
+            authkey = headscale.succeed("headscale preauthkeys -u peer create --reusable")
+
+            # Connect peers
+            up_cmd = f"tailscale up --login-server 'https://headscale' --auth-key {authkey}"
+            peer.execute(up_cmd)
             headscale.succeed("import-pregenerated-keys")
 
-            headscale.succeed("headscale users create bob")
-            authkey = headscale.succeed("headscale preauthkeys -u bob create --reusable")
-            headscale.wait_for_open_port(8080)
-            # alice.start()
-
-            keys = headscale.succeed("headscale preauthkeys list -u bob")
-            print(keys)
-            print(authkey)
-
-            bob.wait_for_unit("tailscaled")
-            bob.succeed("ping -c 1 headscale")
-            bob.succeed("tailscale up --login-server 'https://headscale' --auth-key {authkey}")
-            bob.wait_until_succeeds("tailscale ping alice-boot", timeout=30)
+            alice.start()
+            peer.wait_until_succeeds("tailscale ping alice-boot", timeout=30)
           '';
         };
       };

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -192,9 +192,8 @@
 
             alice.start()
             bob.wait_until_succeeds("tailscale ping alice-boot", timeout=30)
-            print(bob.succeed("ip a ; ip r"))
             bob.succeed("ssh-to-alice", timeout=90)
-            alice.wait_for_unit("multi-user.target")
+            alice.wait_for_unit("multi-user.target", timeout=90)
           '';
         };
       };

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -23,7 +23,7 @@
             alice = {...}: {
               environment.systemPackages = [pkgs.hello];
               imports = [
-                #  self.nixosModules.default
+                self.nixosModules.default
               ];
             };
             bob = {};

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -9,27 +9,143 @@
     final,
     system,
     ...
-  }: {
-    checks = let
-      nixos-lib = import "${inputs.nixpkgs}/nixos/lib" {};
-    in
+  }: let
+    tls-cert = pkgs.runCommand "selfSignedCerts" {buildInputs = [pkgs.openssl];} ''
+      openssl req \
+        -x509 -newkey rsa:4096 -sha256 -days 365 \
+        -nodes -out cert.pem -keyout key.pem \
+        -subj '/CN=headscale' -addext "subjectAltName=DNS:headscale"
+
+      mkdir -p $out
+      cp key.pem cert.pem $out
+    '';
+
+    # OK, so this is pretty lol/lmao.  Since we need working API
+    # keys to build the machines, we have to use "known" API keys
+    # that the headscale server knows about; we also need those in
+    # the environment file that alice's hoopsnake nixos config
+    # module uses; and so: we take a known set of API keys and a DB
+    # dump, adjust a few timings and import that into the running
+    # headscale server.
+    envFiles = {
+      apiKey = pkgs.writeText "apikey-envfile" ''
+        TS_API_KEY=OVehtREWXA._bTQCNek9SsZk5Jy9aIUpGWNWXo61rTh0QTg-_MUCv4
+      '';
+      authKey = pkgs.writeText "apikey-envfile" ''
+        TS_AUTHKEY=e01aa49edded75748e17903330e3f18c25496b47360ffdec
+      '';
+      # Unfortunately, headscale doesn't support oauth client id/secret yet.
+    };
+    dbDump = pkgs.writeText "generated_keys.sql" ''
+      INSERT INTO pre_auth_keys VALUES(1,'e01aa49edded75748e17903330e3f18c25496b47360ffdec',1,0,0,0,datetime(),datetime('now','+1 hour'));
+        INSERT INTO api_keys VALUES(1,'OVehtREWXA',X'24326124313024436f72666574456a30774973344c3745616e697234756e2e536c6746654e71527030694448596153594968355a65374f6742513061',datetime(),datetime('now','+1 hour'),NULL);
+    '';
+    hostkey = pkgs.runCommand "hostkey" {buildInputs = [pkgs.openssh];} ''
+      mkdir $out
+      ssh-keygen -N "" -t ed25519 -f $out/hostkey
+    '';
+    clientKey = pkgs.runCommand "clientKey" {buildInputs = [pkgs.openssh];} ''
+      mkdir $out
+      ssh-keygen -N "" -t ed25519 -f $out/client
+    '';
+    bootloader = {
+      virtualisation.useBootLoader = true;
+      virtualisation.useEFIBoot = true;
+      boot.loader.systemd-boot.enable = true;
+      boot.loader.efi.canTouchEfiVariables = true;
+      environment.systemPackages = [pkgs.efibootmgr];
+    };
+    stunPort = 3478;
+    headscale = {config, ...}: {
+      environment.systemPackages = [
+        (pkgs.writeShellApplication {
+          name = "import-pregenerated-keys";
+          runtimeInputs = [pkgs.sqlite];
+          text = ''
+            sqlite3 /var/lib/headscale/db.sqlite <${dbDump}
+          '';
+        })
+        pkgs.headscale
+      ];
+      services.headscale = {
+        enable = true;
+        settings = {
+          ip_prefixes = ["100.64.0.0/10"];
+          derp.server = {
+            enabled = true;
+            region_id = 999;
+            stun_listen_addr = "0.0.0.0:${toString stunPort}";
+          };
+        };
+      };
+      networking.firewall = {
+        allowedTCPPorts = [443 80];
+        allowedUDPPorts = [stunPort];
+      };
+      services.nginx = {
+        enable = true;
+        virtualHosts.headscale = {
+          addSSL = true;
+          sslCertificate = "${tls-cert}/cert.pem";
+          sslCertificateKey = "${tls-cert}/key.pem";
+          locations."/" = {
+            proxyPass = "http://127.0.0.1:${toString config.services.headscale.port}";
+            proxyWebsockets = true;
+          };
+        };
+      };
+    };
+  in {
+    checks =
       if ! pkgs.lib.hasSuffix "linux" system
       then {}
       else {
-        hoopsnake-starts = nixos-lib.runTest {
+        hoopsnake-starts = pkgs.testers.runNixOSTest {
           name = "hoopsnake-starts";
-          hostPkgs = pkgs;
           nodes = {
+            inherit headscale;
             alice = {...}: {
-              environment.systemPackages = [pkgs.hello];
-              imports = [
-                self.nixosModules.default
-              ];
+              imports = [bootloader self.nixosModules.default];
+              boot.initrd.hoopsnake = {
+                enable = true;
+                ssh = {
+                  authorizedKeysFile = "${clientKey}/client.pub";
+                  privateHostKey = "${hostkey}/hostkey";
+                };
+                tailscale = {
+                  name = "alice-boot";
+                  tags = ["tag:hoopsnake"];
+                  environmentFile = envFiles.authKey;
+                };
+              };
             };
-            bob = {};
+            bob = {
+              services.tailscale.enable = true;
+              systemd.services.tailscaled.serviceConfig.Environment = ["TS_NO_LOGS_NO_SUPPORT=true"];
+              security.pki.certificateFiles = ["${tls-cert}/cert.pem"];
+            };
           };
 
           testScript = ''
+            headscale.start()
+            bob.start()
+            headscale.wait_for_unit("headscale")
+            headscale.succeed("headscale users create alice")
+            headscale.succeed("import-pregenerated-keys")
+
+            headscale.succeed("headscale users create bob")
+            authkey = headscale.succeed("headscale preauthkeys -u bob create --reusable")
+            headscale.wait_for_open_port(8080)
+            # alice.start()
+
+            keys = headscale.succeed("headscale preauthkeys list -u bob")
+            print(keys)
+            print(authkey)
+
+            bob.wait_for_unit("tailscaled")
+            bob.succeed("ping -c 1 headscale")
+            bob.succeed("tailscale up --login-server 'https://headscale' --auth-key {authkey}")
+            bob.wait_until_succeeds("tailscale ping alice-boot", timeout=30)
           '';
         };
       };

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -1,0 +1,37 @@
+{
+  self,
+  inputs,
+  ...
+}: {
+  perSystem = {
+    config,
+    pkgs,
+    final,
+    system,
+    ...
+  }: {
+    checks = let
+      nixos-lib = import "${inputs.nixpkgs}/nixos/lib" {};
+    in
+      if ! pkgs.lib.hasSuffix "linux" system
+      then {}
+      else {
+        hoopsnake-starts = nixos-lib.runTest {
+          name = "hoopsnake-starts";
+          hostPkgs = pkgs;
+          nodes = {
+            alice = {...}: {
+              environment.systemPackages = [pkgs.hello];
+              imports = [
+                #  self.nixosModules.default
+              ];
+            };
+            bob = {};
+          };
+
+          testScript = ''
+          '';
+        };
+      };
+  };
+}

--- a/ssh.go
+++ b/ssh.go
@@ -67,7 +67,7 @@ func (s *TailnetSSH) Run(ctx context.Context, quit <-chan os.Signal) error {
 		Hostname:   s.serviceName,
 		Dir:        s.stateDir,
 		Logf:       logger.Discard,
-		ControlURL: os.Getenv("TS_URL"),
+		ControlURL: os.Getenv("TS_BASE_URL"),
 	}
 	if s.tsnetVerbose {
 		srv.Logf = log.Printf


### PR DESCRIPTION
This adds a `nixosModule.default` and a check that ensures that hoopsnake comes up and is reachable from another node on a tailnet (using the headscale tests as a base again).