### PR TITLE
Handle credentials in a cleaner way

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -63,9 +63,12 @@ To use oauth keypairs,
 2. Generate one on [the oauth clients
    page](https://login.tailscale.com/admin/settings/oauth) and bind it
    to that tag.
-2. Set the env variable `TS_API_CLIENT_ID` to the client ID
-3. Set the env variable `TS_API_CLIENT_SECRET` to the client secret
-4. Run `headscale ...` and it should be a proper tailscale oauth client.
+2. Write the client ID to a file and pass its pathname as `-clientIdFile`
+3. Write the client secret to another file and pass its pathname as `-clientSecretFile`.
+4. (You can also set `TS_API_CLIENT_ID` and `TS_API_CLIENT_SECRET` env
+   variables if those are more convenient. But you can't mix and match
+   the environment variable / file strategy.)
+4. Run `hoopsnake ...` and it should be a proper tailscale oauth client.
 
 ### other considerations: Cleaning out old device entries
 

--- a/ssh.go
+++ b/ssh.go
@@ -16,10 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	gossh "golang.org/x/crypto/ssh"
-	"tailscale.com/client/tailscale"
-	"tailscale.com/ipn/store/mem"
-	"tailscale.com/tsnet"
-	"tailscale.com/types/logger"
 )
 
 var (
@@ -81,37 +77,10 @@ func (s *TailnetSSH) Run(ctx context.Context, quit <-chan os.Signal) error {
 	var err error
 	s.Server.Handler = s.handle
 
-	state, err := mem.New(nil, "")
+	srv, err := s.tsnetServer(ctx)
 	if err != nil {
-		return fmt.Errorf("allocating in-memory state: %w", err)
+		return fmt.Errorf("could not setup a tsnet server: %w", err)
 	}
-	srv := &tsnet.Server{
-		Store:      state,
-		Ephemeral:  true,
-		Hostname:   s.serviceName,
-		Dir:        s.stateDir,
-		Logf:       logger.Discard,
-		ControlURL: os.Getenv("TS_BASE_URL"),
-	}
-	if s.tsnetVerbose {
-		srv.Logf = log.Printf
-	}
-
-	authKey := os.Getenv("TS_AUTHKEY")
-	if authKey == "" {
-		var tsClient *tailscale.Client
-		authKey, tsClient, err = s.mintAuthKey(ctx)
-		if err != nil {
-			return fmt.Errorf("could not mint auth key: %w", err)
-		}
-		if s.deleteExisting {
-			err = s.cleanupOldNodes(ctx, tsClient)
-			if err != nil {
-				return fmt.Errorf("could not clean up old nodes: %w", err)
-			}
-		}
-	}
-	srv.AuthKey = authKey
 
 	_, err = srv.Up(ctx)
 	if err != nil {


### PR DESCRIPTION
Extract the credential retrieval into a function, getCredential that will retrieve the cred from the environment & remove the variable on successful retrieval (this should result in a cleaner environment in downstream processes).

Also, add the two secrets I think users should care about (OAUTH2 client ID and secret) in files whose paths get passed on the commandline.