### PR TITLE
Run in systemd stage1

### DIFF
--- a/cmd/hoopsnake/main.go
+++ b/cmd/hoopsnake/main.go
@@ -16,11 +16,18 @@ func main() {
 		log.Fatalf("Invalid command line: %v", err)
 	}
 
+	ctx := context.Background()
+	ctx, terminate := context.WithCancel(ctx)
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		signal := <-c
+		log.Printf("Received signal %v, terminating...", signal)
+		terminate()
+	}()
 
-	ctx := context.Background()
-	err = cli.Run(ctx, c)
+	err = cli.Run(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/flake.lock
+++ b/flake.lock
@@ -230,11 +230,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1710631334,
-        "narHash": "sha256-rL5LSYd85kplL5othxK5lmAtjyMOBg390sGBTb3LRMM=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c75037bbf9093a2acb617804ee46320d6d1fea5a",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
             vendorHash = builtins.readFile ./default.sri;
             subPackages = ["cmd/hoopsnake"];
             src = lib.sourceFilesBySuffices (lib.sources.cleanSource ./.) [".go" ".mod" ".sum"];
+            CGO_ENABLED = 0;
             meta.mainProgram = "hoopsnake";
           };
         };

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -181,7 +181,7 @@
           )
           credentials;
       in {
-        boot.initrd.systemd.storePaths = [cfg.package];
+        boot.initrd.systemd.storePaths = [cfg.package cfg.ssh.shell];
         boot.initrd.systemd.services.hoopsnake = {
           description = "Hoopsnake initrd ssh server";
           wantedBy = ["initrd.target"];

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -35,9 +35,15 @@
           type = types.path;
         };
         shell = mkOption {
-          description = "The shell package to run";
+          description = "The shell package to run. Used to build boot.initrd.network.hoopsnake.ssh.commandLine.";
           default = "${pkgs.busybox}/bin/ash";
           type = types.oneOf [types.shellPackage types.path];
+        };
+
+        commandLine = mkOption {
+          description = "The concrete commandline to run.";
+          default = [config.boot.initrd.network.hoopsnake.ssh.shell];
+          type = types.listOf types.str;
         };
       };
 
@@ -129,7 +135,7 @@
              -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
              -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
              -hostKey=/etc/hoopsnake/ssh/host_key \
-             ${lib.escapeShellArg cfg.ssh.shell} &
+             ${lib.escapeShellArgs cfg.ssh.commandLine} &
           hoopsnakePid=$!
         '';
         boot.initrd.postMountCommands = ''
@@ -201,7 +207,7 @@
               -hostKey=''${CREDENTIALS_DIRECTORY}/privateHostKey \
               -clientIdFile=''${CREDENTIALS_DIRECTORY}/clientId \
               -clientSecretFile=''${CREDENTIALS_DIRECTORY}/clientSecret \
-              ${lib.escapeShellArg cfg.ssh.shell}
+              ${lib.escapeShellArg cfg.ssh.commandLine}
           '';
 
           environment.HOME = "/tmp";

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -27,17 +27,49 @@
 
       ssh = {
         authorizedKeysFile = mkOption {
-          description = "Path to a file listing the authorized public keys that may authenticate to hoopsnake";
+          description = "Path to a file listing the authorized public keys that may authenticate to hoopsnake.";
           type = types.nullOr types.path;
         };
         privateHostKey = mkOption {
-          description = "Path to a PEM-encoded secret key that the hoopsnake SSH server will use to authenticate itself to clients. This is a secret - it should't live in the nix store.";
+          description = "Path to a PEM-encoded secret key that the hoopsnake SSH server will use to authenticate itself to clients. This is a secret - it should't live in the nix store. Only used in scripted stage1; if you use systemd in initrd, see the systemd-credentials section.";
           type = types.path;
         };
         shell = mkOption {
           description = "The shell package to run";
           default = "${pkgs.busybox}/bin/ash";
           type = types.oneOf [types.shellPackage types.path];
+        };
+      };
+
+      systemd-credentials = let
+        credentialSpec.options = {
+          text = mkOption {
+            description = "A string giving the literal credential. If encrypted, this must be base64-encoded; otherwise, escape non-printable characters with \\x00 and so on.";
+            type = types.str;
+          };
+          file = mkOption {
+            description = "The pathname where a file containing the credential lives.";
+            type = types.nullOr types.path;
+            default = null;
+          };
+          encrypted = mkOption {
+            description = "Whether the credential is presented as encrypted.";
+            type = types.bool;
+            default = true;
+          };
+        };
+      in {
+        privateHostKey = mkOption {
+          description = "systemd credential spec for the SSH private host key.";
+          type = types.submodule credentialSpec;
+        };
+        clientId = mkOption {
+          description = "systemd credential spec for the tailscale OpenID2 client ID.";
+          type = types.submodule credentialSpec;
+        };
+        clientSecret = mkOption {
+          description = "systemd credential spec for the tailscale OpenID2 client secret.";
+          type = types.submodule credentialSpec;
         };
       };
 
@@ -51,7 +83,7 @@
           type = types.nonEmptyListOf (types.strMatching "^tag:.+$");
         };
         environmentFile = mkOption {
-          description = "Environment file setting TS_AUTHKEY, TS_API_KEY or TS_API_CLIENT_ID & TS_API_CLIENT_SECRET. These are secrets, so shouldn't live in the nix store.";
+          description = "Environment file setting TS_AUTHKEY, TS_API_KEY or TS_API_CLIENT_ID & TS_API_CLIENT_SECRET. These are secrets, so shouldn't live in the nix store. Only used in scripted stage1; If you use systemd in initrd, see the systemd-credentials section.";
           type = types.path;
         };
         tsnetVerbose = mkEnableOption "verbose logging from the tsnet package";
@@ -81,50 +113,144 @@
   config = let
     cfg = config.boot.initrd.network.hoopsnake;
   in
-    lib.mkIf cfg.enable {
-      boot.initrd.network.postCommands = ''
-        echo "Starting hoopsnake..."
-        . /etc/hoopsnake/tailscale/environment
-        export TS_AUTHKEY TS_API_KEY TS_API_CLIENT_ID TS_API_CLIENT_SECRET TS_BASE_URL
+    lib.mkIf cfg.enable (lib.mkMerge [
+      (lib.mkIf (!config.boot.initrd.systemd.enable) {
+        # Scripted stage1 (sans systemd-in-initrd):
+        boot.initrd.network.postCommands = ''
+            echo "Starting hoopsnake..."
+          . /etc/hoopsnake/tailscale/environment
+          export TS_AUTHKEY TS_API_KEY TS_API_CLIENT_ID TS_API_CLIENT_SECRET TS_BASE_URL
 
-        ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
-           -tsnetVerbose=${lib.boolToString cfg.tailscale.tsnetVerbose} \
-           -tags=${lib.escapeShellArg (lib.concatStringsSep "," cfg.tailscale.tags)} \
-           -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
-           -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
-           -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
-           -hostKey=/etc/hoopsnake/ssh/host_key \
-           ${lib.escapeShellArg cfg.ssh.shell} &
-        hoopsnakePid=$!
-      '';
-      boot.initrd.postMountCommands = ''
-        if [ -n "$hoopsnakePid" ]; then
-          kill "$hoopsnakePid"
-          ${
-          if cfg.tailscale.cleanup.exitTimeoutSec != null
-          then ''
-            timeToWait=${toString cfg.tailscale.cleanup.exitTimeoutSec}
-            while [ $timeToWait -gt 0 ] && ! kill -0 "$hoopsnakePid" 2>/dev/null ; do
-              timeToWait=$((timeToWait-1))
-              sleep 1
-            done
-          ''
-          else ""
-        }
-        fi
-      '';
-      boot.initrd.secrets = lib.mkMerge [
-        {
-          "/etc/hoopsnake/ssh/host_key" = cfg.ssh.privateHostKey;
-          "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
-          "/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;
-        }
-        (lib.mkIf cfg.includeSSLBundle {
-          "/etc/ssl/ca-bundle.crt" = config.environment.etc."ssl/certs/ca-bundle.crt".source;
-          "/etc/ssl/ca-certificates.crt" = config.environment.etc."ssl/certs/ca-certificates.crt".source;
-          "/etc/pki/tls/certs/ca-bundle.crt" = config.environment.etc."pki/tls/certs/ca-bundle.crt".source;
-          "/etc/ssl/trust-source" = config.environment.etc."ssl/trust-source".source;
-        })
-      ];
-    };
+          ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
+             -tsnetVerbose=${lib.boolToString cfg.tailscale.tsnetVerbose} \
+             -tags=${lib.escapeShellArg (lib.concatStringsSep "," cfg.tailscale.tags)} \
+             -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
+             -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
+             -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
+             -hostKey=/etc/hoopsnake/ssh/host_key \
+             ${lib.escapeShellArg cfg.ssh.shell} &
+          hoopsnakePid=$!
+        '';
+        boot.initrd.postMountCommands = ''
+            if [ -n "$hoopsnakePid" ]; then
+            kill "$hoopsnakePid"
+            ${
+            if cfg.tailscale.cleanup.exitTimeoutSec != null
+            then ''
+              timeToWait=${toString cfg.tailscale.cleanup.exitTimeoutSec}
+              while [ $timeToWait -gt 0 ] && ! kill -0 "$hoopsnakePid" 2>/dev/null ; do
+                timeToWait=$((timeToWait-1))
+                sleep 1
+              done
+            ''
+            else ""
+          }
+          fi
+        '';
+        boot.initrd.secrets = lib.mkMerge [
+          {
+            "/etc/hoopsnake/ssh/host_key" = cfg.ssh.privateHostKey;
+            "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
+            "/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;
+          }
+          (lib.mkIf cfg.includeSSLBundle {
+            "/etc/ssl/ca-bundle.crt" = config.environment.etc."ssl/certs/ca-bundle.crt".source;
+            "/etc/ssl/ca-certificates.crt" = config.environment.etc."ssl/certs/ca-certificates.crt".source;
+            "/etc/pki/tls/certs/ca-bundle.crt" = config.environment.etc."pki/tls/certs/ca-bundle.crt".source;
+            "/etc/ssl/trust-source" = config.environment.etc."ssl/trust-source".source;
+          })
+        ];
+      })
+      (lib.mkIf config.boot.initrd.systemd.enable (let
+        credentials = ["privateHostKey" "clientId" "clientSecret"];
+        textCredentials =
+          lib.concatMap (
+            credName:
+              if (cfg.systemd-credentials.${credName}.file == null)
+              then [credName]
+              else []
+          )
+          credentials;
+        fileCredentials =
+          lib.concatMap (
+            credName:
+              if (cfg.systemd-credentials.${credName}.file != null)
+              then [credName]
+              else []
+          )
+          credentials;
+      in {
+        boot.initrd.systemd.storePaths = [cfg.package];
+        boot.initrd.systemd.services.hoopsnake = {
+          wantedBy = ["initrd.target"];
+          script = ''
+            set -eu -x
+
+            exec ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
+              -tsnetVerbose=${lib.boolToString cfg.tailscale.tsnetVerbose} \
+              -tags=${lib.escapeShellArg (lib.concatStringsSep "," cfg.tailscale.tags)} \
+              -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
+              -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
+              -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
+              -hostKey=''${CREDENTIALS_DIRECTORY}/privateHostKey \
+              -clientIdFile=''${CREDENTIALS_DIRECTORY}/clientId \
+              -clientSecretFile=''${CREDENTIALS_DIRECTORY}/clientSecret \
+              ${lib.escapeShellArg cfg.ssh.shell}
+          '';
+          requires = ["network.target"];
+          after = ["network.target"];
+          serviceConfig = {
+            LoadCredential =
+              lib.concatMap (
+                credName:
+                  if (!cfg.systemd-credentials.${credName}.encrypted)
+                  then ["${credName}:/etc/hoopsnake/${credName}"]
+                  else []
+              )
+              fileCredentials;
+            LoadCredentialEncrypted =
+              lib.concatMap (
+                credName:
+                  if cfg.systemd-credentials.${credName}.encrypted
+                  then ["${credName}:/etc/hoopsnake/${credName}"]
+                  else []
+              )
+              fileCredentials;
+
+            SetCredential =
+              lib.concatMap (
+                credName:
+                  if (!cfg.systemd-credentials.${credName}.encrypted)
+                  then ["${credName}:${cfg.systemd-credentials.${credName}.text}"]
+                  else []
+              )
+              textCredentials;
+            SetCredentialEncrypted =
+              lib.concatMap (
+                credName:
+                  if cfg.systemd-credentials.${credName}.encrypted
+                  then ["${credName}:${cfg.systemd-credentials.${credName}.text}"]
+                  else []
+              )
+              textCredentials;
+          };
+        };
+        boot.initrd.secrets = lib.mkMerge [
+          {
+            "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
+          }
+          (lib.mkIf cfg.includeSSLBundle {
+            "/etc/ssl/ca-bundle.crt" = config.environment.etc."ssl/certs/ca-bundle.crt".source;
+            "/etc/ssl/ca-certificates.crt" = config.environment.etc."ssl/certs/ca-certificates.crt".source;
+            "/etc/pki/tls/certs/ca-bundle.crt" = config.environment.etc."pki/tls/certs/ca-bundle.crt".source;
+            "/etc/ssl/trust-source" = config.environment.etc."ssl/trust-source".source;
+          })
+          (builtins.listToAttrs (builtins.map (credName: {
+              name = "/etc/hoopsnake/${credName}";
+              value = "${cfg.systemd-credentials.${credName}.file}";
+            })
+            fileCredentials))
+        ];
+      }))
+    ]);
 }

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -151,7 +151,6 @@
               ...
             }: {
               imports = [bootloader self.nixosModules.default];
-              services.tailscale.enable = true;
               boot.initrd.preLVMCommands = ''
                 while ! [ -f /tmp/fnord ] ; do
                   sleep 1
@@ -218,36 +217,33 @@
             in {
               imports = [bootloader self.nixosModules.default];
               testing.initrdBackdoor = true;
-              services.tailscale.enable = true;
               boot.initrd.systemd = {
                 enable = true;
                 initrdBin = [fakeShell];
               };
-              boot.initrd.network = {
-                hoopsnake = {
-                  enable = true;
-                  ssh = {
-                    authorizedKeysFile = "${clientKey}/client.pub";
-                    shell = "/bin/success";
-                  };
-                  systemd-credentials = {
-                    privateHostKey.file = "${hostkey}/hostkey";
-                    privateHostKey.encrypted = false;
+              boot.initrd.network.hoopsnake = {
+                enable = true;
+                ssh = {
+                  authorizedKeysFile = "${clientKey}/client.pub";
+                  shell = "/bin/success";
+                };
+                systemd-credentials = {
+                  privateHostKey.file = "${hostkey}/hostkey";
+                  privateHostKey.encrypted = false;
 
-                    # This is a bit janky: The module expects to pass
-                    # a client ID & secret, but we don't have one
-                    # (headscale doesn't support it):
-                    clientId.text = "disabled";
-                    clientId.encrypted = false;
-                    clientSecret.text = "disabled";
-                    clientSecret.encrypted = false;
-                  };
-                  tailscale = {
-                    name = "alice-boot";
-                    tags = ["tag:hoopsnake"];
-                    environmentFile = envFiles.authKey;
-                    tsnetVerbose = true;
-                  };
+                  # This is a bit janky: The module expects to pass
+                  # a client ID & secret, but we don't have one
+                  # (headscale doesn't support it):
+                  clientId.text = "disabled";
+                  clientId.encrypted = false;
+                  clientSecret.text = "disabled";
+                  clientSecret.encrypted = false;
+                };
+                tailscale = {
+                  name = "alice-boot";
+                  tags = ["tag:hoopsnake"];
+                  environmentFile = envFiles.authKey;
+                  tsnetVerbose = true;
                 };
               };
             };

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -51,6 +51,8 @@
     bootloader = {config, ...}: {
       virtualisation.useBootLoader = true;
       virtualisation.useEFIBoot = true;
+      virtualisation.cores = 4;
+      virtualisation.memorySize = 1024;
       boot.loader.systemd-boot.enable = true;
       boot.loader.efi.canTouchEfiVariables = true;
       environment.systemPackages = [pkgs.efibootmgr];

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -57,11 +57,6 @@
       boot.kernelParams = [
         "ip=${config.networking.primaryIPAddress}:::255.255.255.0::eth1:off"
       ];
-      boot.initrd.preLVMCommands = ''
-        while ! [ -f /tmp/fnord ] ; do
-            sleep 1
-        done
-      '';
       boot.initrd.network = {
         enable = true;
         udhcpc.enable = false;
@@ -117,39 +112,39 @@
         })
       ];
     };
-  in {
-    checks =
-      if ! pkgs.lib.hasSuffix "linux" system
-      then {}
-      else {
-        hoopsnake-starts = pkgs.testers.runNixOSTest {
-          name = "hoopsnake-starts";
-          nodes = {
-            inherit headscale;
-            bob = {
-              services.tailscale.enable = true;
-              security.pki.certificateFiles = ["${tls-cert}/cert.pem"];
-              networking.useDHCP = false;
-              environment.etc.sshKey = {
-                source = "${clientKey}/client";
-                mode = "0600";
-              };
-              environment.systemPackages = [
-                (pkgs.writeShellApplication {
-                  name = "ssh-to-alice";
-                  runtimeInputs = [pkgs.openssh];
-                  text = ''
-                    echo "${hostkey} fingerprint:" >&2
+    bob = {
+      services.tailscale.enable = true;
+      security.pki.certificateFiles = ["${tls-cert}/cert.pem"];
+      networking.useDHCP = false;
+      environment.etc.sshKey = {
+        source = "${clientKey}/client";
+        mode = "0600";
+      };
+      environment.systemPackages = [
+        (pkgs.writeShellApplication {
+          name = "ssh-to-alice";
+          runtimeInputs = [pkgs.openssh];
+          text = ''
+            echo "${hostkey} fingerprint:" >&2
                     ssh-keygen -l -f ${hostkey}/hostkey
                     echo "${hostkey} contents:" >&2
                     cat ${hostkey}/hostkey >&2
                     echo "${hostkey}/known_hosts file contents:" >&2
                     cat ${hostkey}/known_hosts >&2
                     echo | ssh -vvv -o UserKnownHostsFile=${hostkey}/known_hosts -i /etc/sshKey shell@alice-boot
-                  '';
-                })
-              ];
-            };
+          '';
+        })
+      ];
+    };
+  in {
+    checks =
+      if ! pkgs.lib.hasSuffix "linux" system
+      then {}
+      else {
+        hoopsnake-scripted = pkgs.testers.runNixOSTest {
+          name = "hoopsnake-scripted-initrd-stage1";
+          nodes = {
+            inherit headscale bob;
             alice = {
               lib,
               config,
@@ -157,6 +152,12 @@
             }: {
               imports = [bootloader self.nixosModules.default];
               services.tailscale.enable = true;
+              boot.initrd.preLVMCommands = ''
+                while ! [ -f /tmp/fnord ] ; do
+                  sleep 1
+                done
+              '';
+
               boot.initrd.network = {
                 hoopsnake = {
                   enable = true;
@@ -180,23 +181,93 @@
           };
 
           testScript = ''
-            for node in [headscale, bob]:
-                node.start()
-            headscale.wait_for_unit("headscale")
-            headscale.wait_for_open_port(443)
+            with subtest("Test setup"):
+                for node in [headscale, bob]:
+                    node.start()
+                headscale.wait_for_unit("headscale")
+                headscale.wait_for_open_port(443)
 
-            # Create headscale user and preauth-key
-            headscale.succeed("headscale users create bob")
-            authkey = headscale.succeed("headscale preauthkeys -u bob create --reusable")
+                # Create headscale user and preauth-key
+                headscale.succeed("headscale users create bob")
+                authkey = headscale.succeed("headscale preauthkeys -u bob create --reusable")
 
-            # Connect peers
-            up_cmd = f"tailscale up --login-server 'https://headscale' --auth-key {authkey}"
-            bob.execute(up_cmd)
-            headscale.succeed("import-pregenerated-keys")
+                # Connect peers
+                up_cmd = f"tailscale up --login-server 'https://headscale' --auth-key {authkey}"
+                bob.execute(up_cmd)
+                headscale.succeed("import-pregenerated-keys")
 
             alice.start()
             bob.wait_until_succeeds("tailscale ping alice-boot", timeout=30)
             bob.succeed("ssh-to-alice", timeout=90)
+            alice.wait_for_unit("multi-user.target", timeout=90)
+          '';
+        };
+        hoopsnake-systemd = pkgs.testers.runNixOSTest {
+          name = "hoopsnake-systemd-initrd-stage1";
+          nodes = {
+            inherit headscale bob;
+            alice = {
+              lib,
+              config,
+              ...
+            }: {
+              imports = [bootloader self.nixosModules.default];
+              testing.initrdBackdoor = true;
+              services.tailscale.enable = true;
+              boot.initrd.systemd = {
+                enable = true;
+              };
+              boot.initrd.network = {
+                hoopsnake = {
+                  enable = true;
+                  ssh = {
+                    authorizedKeysFile = "${clientKey}/client.pub";
+                    shell = lib.getExe (pkgs.writeShellApplication {
+                      name = "success";
+                      text = "touch /tmp/fnord";
+                    });
+                  };
+                  systemd-credentials = {
+                    # TODO
+                    privateHostKey.file = "${hostkey}/hostkey";
+                    privateHostKey.encrypted = false;
+                    clientId.text = "hi";
+                    clientId.encrypted = false;
+                    clientSecret.text = "hello";
+                    clientSecret.encrypted = false;
+                  };
+                  tailscale = {
+                    name = "alice-boot";
+                    tags = ["tag:hoopsnake"];
+                    environmentFile = envFiles.authKey;
+                    tsnetVerbose = true;
+                  };
+                };
+              };
+            };
+          };
+
+          testScript = ''
+            with subtest("Test setup"):
+                for node in [headscale, bob]:
+                        node.start()
+                headscale.wait_for_unit("headscale")
+                headscale.wait_for_open_port(443)
+
+                # Create headscale user and preauth-key
+                headscale.succeed("headscale users create bob")
+                authkey = headscale.succeed("headscale preauthkeys -u bob create --reusable")
+
+                # Connect peers
+                up_cmd = f"tailscale up --login-server 'https://headscale' --auth-key {authkey}"
+                bob.execute(up_cmd)
+                headscale.succeed("import-pregenerated-keys")
+
+            alice.start()
+            bob.wait_until_succeeds("tailscale ping alice-boot", timeout=30)
+            bob.succeed("ssh-to-alice", timeout=90)
+            alice.wait_until_succeeds("test -f /tmp/fnord")
+            alice.switch_root()
             alice.wait_for_unit("multi-user.target", timeout=90)
           '';
         };

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -222,6 +222,7 @@
               boot.initrd.systemd = {
                 enable = true;
                 initrdBin = [fakeShell];
+                extraConfig = "LogLevel=debug";
               };
               boot.initrd.network.hoopsnake = {
                 enable = true;

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -267,12 +267,15 @@
                 bob.execute(up_cmd)
                 headscale.succeed("import-pregenerated-keys")
 
-            alice.start()
-            bob.wait_until_succeeds("tailscale ping alice-boot", timeout=30)
-            bob.succeed("ssh-to-alice", timeout=90)
-            alice.wait_until_succeeds("test -f /tmp/fnord")
-            alice.switch_root()
-            alice.wait_for_unit("multi-user.target", timeout=90)
+            with subtest("Unlock alice's boot progress"):
+                alice.start()
+                bob.wait_until_succeeds("tailscale ping alice-boot", timeout=30)
+                bob.succeed("ssh-to-alice", timeout=90)
+                alice.wait_until_succeeds("test -f /tmp/fnord")
+                alice.switch_root()
+
+            with subtest("Finish booting alice"):
+                alice.wait_for_unit("multi-user.target", timeout=90)
           '';
         };
       };

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -222,7 +222,6 @@
               boot.initrd.systemd = {
                 enable = true;
                 initrdBin = [fakeShell];
-                extraConfig = "LogLevel=debug";
               };
               boot.initrd.network.hoopsnake = {
                 enable = true;

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -231,9 +231,13 @@
                     # TODO
                     privateHostKey.file = "${hostkey}/hostkey";
                     privateHostKey.encrypted = false;
-                    clientId.text = "hi";
+
+                    # This is a bit janky: The module expects to pass
+                    # a client ID & secret, but we don't have one
+                    # (headscale doesn't support it):
+                    clientId.text = "disabled";
                     clientId.encrypted = false;
-                    clientSecret.text = "hello";
+                    clientSecret.text = "disabled";
                     clientSecret.encrypted = false;
                   };
                   tailscale = {

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -228,7 +228,7 @@
                 enable = true;
                 ssh = {
                   authorizedKeysFile = "${clientKey}/client.pub";
-                  shell = "/bin/success";
+                  commandLine = ["/bin/success"];
                 };
                 systemd-credentials = {
                   privateHostKey.file = "${hostkey}/hostkey";


### PR DESCRIPTION
This allows us to run under systemd, which lets us set credentials encrypted with a TPM2! 

That means the entire key management bit is solved, and we have a way to boot a stateless initrd whose trust is 100% rooted in a machine identity.