### PR TITLE
Start after network-online.target, not network.target

### DIFF
--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -191,7 +191,7 @@
         boot.initrd.systemd.services.hoopsnake = {
           description = "Hoopsnake initrd ssh server";
           wantedBy = ["initrd.target"];
-          after = ["network.target" "initrd-nixos-copy-secrets.service"];
+          after = ["network-online.target" "initrd-nixos-copy-secrets.service"];
           before = ["shutdown.target" "initrd-switch-root.target"];
           conflicts = ["shutdown.target" "initrd-switch-root.target"];
 


### PR DESCRIPTION
Oops: I missed that distinction; network-online is when the interfaces have addresses, which should fix the race condition we saw in tests on github.