### PR TITLE
Correct error handling on exit when serving prometheus metrics

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -29,9 +29,10 @@ func (s *TailnetSSH) setupPrometheus(ctx context.Context, srv *tsnet.Server) err
 			Handler:           mux,
 			ReadHeaderTimeout: 1 * time.Second,
 		}
-		if ctx.Err() == nil {
+		err := server.Serve(listener)
+		if err != nil && ctx.Err() == nil {
 			// Failed to listen but not asked to shut down:
-			log.Printf("Failed to listen on prometheus address: %v", server.Serve(listener))
+			log.Printf("Failed to listen on prometheus address: %v", err)
 			os.Exit(20)
 		}
 	}()


### PR DESCRIPTION
The logic for serving prometheus metrics was somewhat broken: It would attempt to check that the cancellation context didn't indicate that we should exit, but it would only do that _before_ starting to serve.

Instead, first serve, and if serve returns a fault, check whether we're meant to exit. Oops.