### PR TITLE
Correct the usage of tokens in SRI update workflow

### DIFF
--- a/.github/workflows/regenerate-go-sri.yml
+++ b/.github/workflows/regenerate-go-sri.yml
@@ -28,14 +28,17 @@ jobs:
       contents: write
     steps:
       - name: Generate token
-        id: generate-token
+        id: generate_token
         uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ vars.PR_FIXUP_APP_ID }}
           private_key: ${{ secrets.PR_FIXUP_APP_PRIVATE_KEY }}
+          installation_id: ${{ vars.PR_FIXUP_INSTALLATION_ID }}
+          permissions: >-
+            {"contents": "write", "pull_requests": "write"}
       - uses: actions/checkout@v4
         with:
-          token: ${{secrets.REPO_CONTENT_UPDATE_TOKEN}}
+          token: ${{steps.generate_token.outputs.token}}
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       - uses: cachix/install-nix-action@v30
       - uses: DeterminateSystems/magic-nix-cache-action@v8
@@ -53,7 +56,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         if: github.event_name != 'workflow_dispatch' || !github.event.inputs.push_change
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.generate_token.outputs.token }}
           author: Flakes Updater <noreply+flakes-updater@boinkor.net>
           committer: Flakes Updater <noreply+flakes-updater@boinkor.net>
           branch: auto-update-sri


### PR DESCRIPTION
This used an outdated / no-longer-used token; let's see if I can use the app instead (which is what it was intended to use anyway).