### PR TITLE
Specify CGO_ENABLED with env.CGO_ENABLED now

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
             vendorHash = builtins.readFile ./default.sri;
             subPackages = ["cmd/hoopsnake"];
             src = lib.sourceFilesBySuffices (lib.sources.cleanSource ./.) [".go" ".mod" ".sum"];
-            CGO_ENABLED = 0;
+            env.CGO_ENABLED = 0;
             meta.mainProgram = "hoopsnake";
           };
         };


### PR DESCRIPTION
The previous way got deprecated in recent nixpkgs, so now we have to do it like this.