### PR TITLE
Improve reliability of nix tests

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -151,11 +151,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1726463316,
-        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
+        "lastModified": 1739736696,
+        "narHash": "sha256-zON2GNBkzsIyALlOCFiEBcIjI4w38GYOb+P+R4S8Jsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+        "rev": "d74a2335ac9c133d6bbec9fc98d91a77f1604c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Previously, we'd import an offline-generated headscale DB dump containing api and preauth keys that hoopsnake can use. That's sadly not viable now that headscale is upgraded in nixpkgs-unstable.

Instead, let's generate the keys in an "offline" headscale at build time and take a db dump there. It's just as gross, but at least it'll not be breaking as easily!