### PR TITLE
Add a -configtest commandline flag

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -48,6 +48,7 @@ type TailnetSSH struct {
 	tags               []string
 	command            []string
 	authorizedPubKeys  []gossh.PublicKey
+	configTestOnly     bool
 }
 
 var ErrMissingServiceName = fmt.Errorf("service name must be set via -name")
@@ -69,6 +70,7 @@ func TailnetSSHFromArgs(args []string) (*TailnetSSH, error) {
 	fs.StringVar(&s.prometheusAddr, "prometheusAddr", ":9021", "Address on the tailnet node where prometheus requests get answered")
 	fs.StringVar(&s.clientIDFile, "clientIdFile", "", "File containing the tailscale OAUTH2 client ID")
 	fs.StringVar(&s.clientSecretFile, "clientSecretFile", "", "File containing the tailscale OAUTH2 client secret")
+	fs.BoolVar(&s.configTestOnly, "configtest", false, "Validate that authkeys can be generated. Exits 0 if everything works.")
 
 	var tags string
 	fs.StringVar(&tags, "tags", "", "Tailnet ACL tags assigned to the node, comma-separated")

--- a/ssh.go
+++ b/ssh.go
@@ -96,6 +96,12 @@ func (s *TailnetSSH) Run(ctx context.Context) error {
 		return fmt.Errorf("could not listen on tailnet: %w", err)
 	}
 
+	if s.configTestOnly {
+		log.Printf("Configuration tested ok")
+		srv.Close()
+		return nil
+	}
+
 	go func() {
 		<-ctx.Done()
 		srv.Close()


### PR DESCRIPTION
This PR adds a flag that has hoopsnake attempt to authenticate to the tailscale service, register a node and bring up SSH service on it. This should ultimately allow a pre-run sanity check for people deploying a hoopsnake config to servers, giving us all confidence that the machine will be able to boot next time.