### PR TITLE
Detach tsnet cancellation from SSH server termination

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -85,7 +85,11 @@ func (s *TailnetSSH) Run(ctx context.Context) error {
 		return fmt.Errorf("could not setup a tsnet server: %w", err)
 	}
 
-	_, err = srv.Up(ctx)
+	// Do not shut down the tsnet server as soon as we're meant
+	// to close client connections; it shuts down after the
+	// SSH server terminates.
+	netCtx := context.WithoutCancel(ctx)
+	_, err = srv.Up(netCtx)
 	if err != nil {
 		return fmt.Errorf("could not connect to tailnet: %w", err)
 	}


### PR DESCRIPTION
Shutting down the tsnet interface at the same time as the SSH server results in connected clients not getting the notification that their connection was terminated.

So, create a child context for the tsnet service that doesn't cancel immediately; instead, set it up with its own cancellation handler that gets invoked once the SSH server is shut down.

This fixes #106.