### PR TITLE
Correctly sequence the shutdown operations

### DIFF
--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -66,7 +66,7 @@
 
         headscale users create --config ./config.yaml bob
         api_key="$(headscale apikeys create --config ./config.yaml)"
-        auth_key="$(headscale preauthkeys create --reusable -e 24h --config ./config.yaml -u bob)"
+        auth_key="$(headscale preauthkeys create --reusable -e 100y --config ./config.yaml -u bob)"
         cat >$out/apikey-envfile <<EOF
         TS_API_KEY=$api_key
         TS_BASE_URL=${config.server_url}
@@ -235,11 +235,11 @@
             def wait_for_hoopsnake_registered(name):
                 "Poll until hoopsnake appears in the list of hosts, then return its IP."
                 while True:
-                    output = json.loads(headscale.succeed("headscale nodes list -o json-line"))
-                    print(output)
-                    basic_entry = [elt["ip_addresses"][0] for elt in output if elt["given_name"] == name]
-                    if len(basic_entry) == 1:
-                        return basic_entry[0]
+                    status = json.loads(bob.succeed("tailscale status --json --peers --self=false"))
+                    if status["Peer"] is not None:
+                      basic_entry = [elt["TailscaleIPs"][0] for _, elt in status["Peer"].items() if elt["HostName"] == name]
+                      if len(basic_entry) == 1:
+                          return basic_entry[0]
                     time.sleep(1)
 
 
@@ -319,11 +319,11 @@
             def wait_for_hoopsnake_registered(name):
                 "Poll until hoopsnake appears in the list of hosts, then return its IP."
                 while True:
-                    output = json.loads(headscale.succeed("headscale nodes list -o json-line"))
-                    print(output)
-                    basic_entry = [elt["ip_addresses"][0] for elt in output if elt["given_name"] == name]
-                    if len(basic_entry) == 1:
-                        return basic_entry[0]
+                    status = json.loads(bob.succeed("tailscale status --json --peers --self=false"))
+                    if status["Peer"] is not None:
+                      basic_entry = [elt["TailscaleIPs"][0] for _, elt in status["Peer"].items() if elt["HostName"] == name]
+                      if len(basic_entry) == 1:
+                          return basic_entry[0]
                     time.sleep(1)
 
             with subtest("Test setup"):

--- a/ssh.go
+++ b/ssh.go
@@ -106,16 +106,15 @@ func (s *TailnetSSH) Run(ctx context.Context) error {
 		return nil
 	}
 
-	go func() {
-		<-ctx.Done()
-		srv.Close()
-	}()
-
 	err = s.setupPrometheus(ctx, srv)
 	if err != nil {
 		log.Printf("Setting up prometheus failed, but continuing anyway: %v", err)
 	}
 	log.Printf("starting ssh server on port :22...")
+	go func() {
+		<-ctx.Done()
+		_ = s.Server.Close()
+	}()
 	err = s.Server.Serve(listener)
 	if err != nil && ctx.Err() == nil {
 		return fmt.Errorf("ssh server failed serving: %w", err)


### PR DESCRIPTION
I got the order of things getting shut down wrong: Instead of shutting down the SSH server, the sequence still shut down the _tailscale_ server, which had the exact same effect as before #107.

Instead, wait for the termination message, then shut down the SSH server, which causes the tailscale client to shut down.

I have tested this on my local system, and there it fixes #106.