### PR TITLE
Correctly declare a dependency on network-online.target

### DIFF
--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -191,6 +191,7 @@
         boot.initrd.systemd.services.hoopsnake = {
           description = "Hoopsnake initrd ssh server";
           wantedBy = ["initrd.target"];
+          wants = ["network-online.target"];
           after = ["network-online.target" "initrd-nixos-copy-secrets.service"];
           before = ["shutdown.target" "initrd-switch-root.target"];
           conflicts = ["shutdown.target" "initrd-switch-root.target"];


### PR DESCRIPTION
According to https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#network-online.target, units that require the network to be reachable need to declare a Wants relationship and order themselves after network-online.target.

This ought to finally fix the issue where hoopsnake can't start on some systems (where it gets ordered before the network is up) and those systems enter emergency mode.

This fixes #105 