### PR TITLE
module: fix `hoopsnake` not starting sometimes in `systemd` stage-1

### DIFF
--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -195,6 +195,7 @@
           after = ["network-online.target" "initrd-nixos-copy-secrets.service"];
           before = ["shutdown.target" "initrd-switch-root.target"];
           conflicts = ["shutdown.target" "initrd-switch-root.target"];
+          unitConfig.DefaultDependencies = false;
 
           script = ''
             set -eu -x


### PR DESCRIPTION
Without this, `hoopsnake` doesn't start on boot when running [preservation](https://github.com/nix-community/preservation). I believe this will also affect users who run [impermanence](https://github.com/nix-community/impermanence).