### PR TITLE
buildGoModule: use `env` to specify environment variables

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,13 +23,13 @@
 
         packages = {
           default = config.packages.hoopsnake;
-          hoopsnake = pkgs.buildGo123Module rec {
+          hoopsnake = pkgs.buildGo123Module {
             pname = "hoopsnake";
             version = "0.0.0";
             vendorHash = builtins.readFile ./default.sri;
             subPackages = ["cmd/hoopsnake"];
             src = lib.sourceFilesBySuffices (lib.sources.cleanSource ./.) [".go" ".mod" ".sum"];
-            CGO_ENABLED = 0;
+            env.CGO_ENABLED = 0;
             meta.mainProgram = "hoopsnake";
           };
         };


### PR DESCRIPTION
Fixes `evaluation warning: /nix/store/4yblc789s08qlhrlw37y2f9lkxisk7b4-source/flake.nix:28: buildGoModule: specify CGO_ENABLED with env.CGO_ENABLED instead.`