### PR TITLE
hoopsnake: don't use Go 1.23 as it is EOL now

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,69 @@
+version: "2"
 run:
   concurrency: 4
-  timeout: 3m
   tests: false
-
 linters:
-  presets:
-    - bugs
-    - comment
-    - error
-    - import
-    - metalinter
-    - module
-    - performance
-    - sql
-    - unused
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - dupword
+    - durationcheck
+    - err113
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - fatcontext
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gocritic
+    - godot
+    - godox
+    - gomoddirectives
+    - gomodguard
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
+    - misspell
+    - musttag
+    - nilerr
+    - nilnesserr
+    - noctx
+    - prealloc
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unparam
+    - wrapcheck
+    - zerologlint
   disable:
     - depguard
-    - gci
     - perfsprint
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754091436,
-        "narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "tailscale": "tailscale"
       },
       "locked": {
-        "lastModified": 1739117370,
-        "narHash": "sha256-71PNfk4UONMds2ym0lUz4TazFdEmJshXAO3WVrN50FY=",
+        "lastModified": 1757686793,
+        "narHash": "sha256-1VcFAVY+BsKn3fiOObrKjZG5hb/k52B7BxB/JHwyxVo=",
         "owner": "antifuchs",
         "repo": "generate-go-sri",
-        "rev": "3c3ec91c8f53952182fc81e7217b9156c1fafd38",
+        "rev": "1ce154eed2fa99ed747a274bbe70ad66666612da",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726583932,
-        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
+        "lastModified": 1757584362,
+        "narHash": "sha256-XeTX/w16rUNUNBsfaOVCDoMMa7Xu7KvIMT7tn1zIEcg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "658e7223191d2598641d50ee4e898126768fe847",
+        "rev": "d33e926c80e6521a55da380a4c4c44a7462af405",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1753939845,
-        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94def634a20494ee057c76998843c015909d6311",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {
@@ -129,16 +129,17 @@
     "tailscale": {
       "flake": false,
       "locked": {
-        "lastModified": 1739025941,
-        "narHash": "sha256-ySxjsXj8VEGXj+XNzXyi46bCe4H/FkFIduQFg6grJWw=",
+        "lastModified": 1757355219,
+        "narHash": "sha256-rrT/oOkdMcSfSL45Lt87cL8rxt7MUbMs/ziL9O7hmOE=",
         "owner": "tailscale",
         "repo": "tailscale",
-        "rev": "532e38bdc82cd61d0e72cdca89093fd92baa1db2",
+        "rev": "2da52dce7aba5150b7b9e637b9fb0d7307fed916",
         "type": "github"
       },
       "original": {
         "owner": "tailscale",
         "repo": "tailscale",
+        "rev": "2da52dce7aba5150b7b9e637b9fb0d7307fed916",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           perSystem = {pkgs, ...}: {
             devshells.default = {
               packages = [
-                pkgs.go_1_23
+                pkgs.go
                 pkgs.golangci-lint
               ];
             };
@@ -40,7 +40,7 @@
 
         packages = {
           default = config.packages.hoopsnake;
-          hoopsnake = pkgs.buildGo123Module {
+          hoopsnake = pkgs.buildGoModule {
             pname = "hoopsnake";
             version = "0.0.0";
             vendorHash = builtins.readFile ./default.sri;

--- a/ssh.go
+++ b/ssh.go
@@ -137,7 +137,7 @@ func setWinsize(f *os.File, width, height int) {
 
 func (s *TailnetSSH) handle(sess ssh.Session) {
 	// The command is passed in from the CLI, it's trusted by fiat:
-	cmd := exec.Command(s.command[0], s.command[1:]...) // #nosec G204
+	cmd := exec.CommandContext(sess.Context(), s.command[0], s.command[1:]...) // #nosec G204
 
 	ptyReq, winCh, isPty := sess.Pty()
 	if isPty {

--- a/ssh.go
+++ b/ssh.go
@@ -43,7 +43,7 @@ func (s *TailnetSSH) setupAuthorizedKeys() error {
 		}
 	}
 	if len(s.authorizedPubKeys) > 0 {
-		s.Server.PublicKeyHandler = s.validatePubkey
+		s.PublicKeyHandler = s.validatePubkey
 	}
 	return nil
 }
@@ -78,7 +78,7 @@ func (s *TailnetSSH) setupHostKey() error {
 // errors are fatal.
 func (s *TailnetSSH) Run(ctx context.Context) error {
 	var err error
-	s.Server.Handler = s.handle
+	s.Handler = s.handle
 
 	srv, err := s.tsnetServer(ctx)
 	if err != nil {
@@ -113,9 +113,9 @@ func (s *TailnetSSH) Run(ctx context.Context) error {
 	log.Printf("starting ssh server on port :22...")
 	go func() {
 		<-ctx.Done()
-		_ = s.Server.Close()
+		_ = s.Close()
 	}()
-	err = s.Server.Serve(listener)
+	err = s.Serve(listener)
 	if err != nil && ctx.Err() == nil {
 		return fmt.Errorf("ssh server failed serving: %w", err)
 	}

--- a/ssh.go
+++ b/ssh.go
@@ -35,7 +35,7 @@ func (s *TailnetSSH) setupAuthorizedKeys() error {
 		for len(authorizedKeysBytes) > 0 {
 			pubKey, _, _, rest, err := ssh.ParseAuthorizedKey(authorizedKeysBytes)
 			if err != nil {
-				return fmt.Errorf("Could not parse authorized key: %w", err)
+				return fmt.Errorf("could not parse authorized key: %w", err)
 			}
 
 			s.authorizedPubKeys = append(s.authorizedPubKeys, pubKey)


### PR DESCRIPTION
```
error:
       … while evaluating the attribute 'optionalValue.value'
         at /nix/store/pbjhvm05kpn4w79vlr70gc8cad2dgngp-source/lib/modules.nix:1182:5:
         1181|
         1182|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |     ^
         1183|   };

       … while evaluating a branch condition
         at /nix/store/pbjhvm05kpn4w79vlr70gc8cad2dgngp-source/lib/modules.nix:1182:21:
         1181|
         1182|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |                     ^
         1183|   };

       … while evaluating definitions from `/nix/store/iiiq8zn29mz0yd8lllpnimn1dpm3ydn5-source/modules/transposition.nix':

       … while evaluating definitions from `/nix/store/8v9nc6wm230mpzb0847a01km62a9r0p7-source/flake.nix, via option perSystem':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Go 1.23 is end-of-life, and 'buildGo123Module' has been removed. Please use a newer builder version.
```