### PR TITLE
Fix calling commands with arguments

### DIFF
--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -209,7 +209,7 @@
               -hostKey=''${CREDENTIALS_DIRECTORY}/privateHostKey \
               -clientIdFile=''${CREDENTIALS_DIRECTORY}/clientId \
               -clientSecretFile=''${CREDENTIALS_DIRECTORY}/clientSecret \
-              ${lib.escapeShellArg cfg.ssh.commandLine}
+              ${lib.escapeShellArgs cfg.ssh.commandLine}
           '';
 
           environment.HOME = "/tmp";


### PR DESCRIPTION
I set:

```nix
{
  boot.initrd.network.hoopsnake.ssh.commandLine = [ "/bin/systemctl" "default" ];
}
```

This would fail with:

```
Error starting the command in a PTY: exec: "systemctl default": executable file not found in $PATH
```

This is because `lib.escapeShellArg [ "/bin/systemctl" "default" ]` returns `'/bin/systemctl default'` instead of `/bin/systemctl default`