### PR TITLE
Warn if building with scripted initrd, update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722073938,
-        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
+        "lastModified": 1762156382,
+        "narHash": "sha256-Yg7Ag7ov5+36jEFC1DaZh/12SEXo6OO3/8rqADRxiqs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
+        "rev": "7241bcbb4f099a66aafca120d37c65e8dda32717",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -37,7 +37,10 @@
         shell = mkOption {
           description = "The shell package to run. Used to build boot.initrd.network.hoopsnake.ssh.commandLine.";
           default = "${pkgs.busybox}/bin/ash";
-          type = types.oneOf [types.shellPackage types.path];
+          type = types.oneOf [
+            types.shellPackage
+            types.path
+          ];
         };
 
         commandLine = mkOption {
@@ -121,158 +124,186 @@
   config = let
     cfg = config.boot.initrd.network.hoopsnake;
   in
-    lib.mkIf cfg.enable (lib.mkMerge [
-      (lib.mkIf (!config.boot.initrd.systemd.enable) {
-        # Scripted stage1 (sans systemd-in-initrd):
-        boot.initrd.network.postCommands = ''
-            echo "Starting hoopsnake..."
-          . /etc/hoopsnake/tailscale/environment
-          export TS_AUTHKEY TS_API_KEY TS_API_CLIENT_ID TS_API_CLIENT_SECRET TS_BASE_URL
+    lib.mkIf cfg.enable (
+      lib.mkMerge [
+        (lib.mkIf (!config.boot.initrd.systemd.enable) {
+          # Scripted stage1 (sans systemd-in-initrd):
+          boot.initrd.network.postCommands = lib.trivial.warn "Using scripted initrd with hoopsnake is deprecated as nixos will soon switch to systemd initrd only." ''
+              echo "Starting hoopsnake..."
+            . /etc/hoopsnake/tailscale/environment
+            export TS_AUTHKEY TS_API_KEY TS_API_CLIENT_ID TS_API_CLIENT_SECRET TS_BASE_URL
 
-          ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
-             -tsnetVerbose=${lib.boolToString cfg.tailscale.tsnetVerbose} \
-             -preauthorized=${lib.boolToString cfg.tailscale.preauthorized} \
-             -tags=${lib.escapeShellArg (lib.concatStringsSep "," cfg.tailscale.tags)} \
-             -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
-             -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
-             -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
-             -hostKey=/etc/hoopsnake/ssh/host_key \
-             ${lib.escapeShellArgs cfg.ssh.commandLine} &
-          hoopsnakePid=$!
-        '';
-        boot.initrd.postMountCommands = ''
-            if [ -n "$hoopsnakePid" ]; then
-            kill "$hoopsnakePid"
-            ${
-            if cfg.tailscale.cleanup.exitTimeoutSec != null
-            then ''
-              timeToWait=${toString cfg.tailscale.cleanup.exitTimeoutSec}
-              while [ $timeToWait -gt 0 ] && ! kill -0 "$hoopsnakePid" 2>/dev/null ; do
-                timeToWait=$((timeToWait-1))
-                sleep 1
-              done
-            ''
-            else ""
-          }
-          fi
-        '';
-        boot.initrd.secrets = lib.mkMerge [
-          {
-            "/etc/hoopsnake/ssh/host_key" = cfg.ssh.privateHostKey;
-            "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
-          }
-          (lib.mkIf (cfg.tailscale.environmentFile != null) {"/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;})
-          (lib.mkIf cfg.includeSSLBundle {
-            "/etc/ssl/ca-bundle.crt" = config.environment.etc."ssl/certs/ca-bundle.crt".source;
-            "/etc/ssl/ca-certificates.crt" = config.environment.etc."ssl/certs/ca-certificates.crt".source;
-            "/etc/pki/tls/certs/ca-bundle.crt" = config.environment.etc."pki/tls/certs/ca-bundle.crt".source;
-            "/etc/ssl/trust-source" = config.environment.etc."ssl/trust-source".source;
-          })
-        ];
-      })
-      (lib.mkIf config.boot.initrd.systemd.enable (let
-        credentials = ["privateHostKey" "clientId" "clientSecret"];
-        textCredentials =
-          lib.concatMap (
-            credName:
-              if (cfg.systemd-credentials.${credName}.file == null)
-              then [credName]
-              else []
-          )
-          credentials;
-        fileCredentials =
-          lib.concatMap (
-            credName:
-              if (cfg.systemd-credentials.${credName}.file != null)
-              then [credName]
-              else []
-          )
-          credentials;
-      in {
-        boot.initrd.systemd.storePaths = [cfg.package cfg.ssh.shell];
-        boot.initrd.systemd.services.hoopsnake = {
-          description = "Hoopsnake initrd ssh server";
-          wantedBy = ["initrd.target"];
-          wants = ["network-online.target"];
-          after = ["network-online.target" "initrd-nixos-copy-secrets.service"];
-          before = ["shutdown.target" "initrd-switch-root.target"];
-          conflicts = ["shutdown.target" "initrd-switch-root.target"];
-          unitConfig.DefaultDependencies = false;
-
-          script = ''
-            set -eu -x
-
-            exec ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
-              -tsnetVerbose=${lib.boolToString cfg.tailscale.tsnetVerbose} \
-              -preauthorized=${lib.boolToString cfg.tailscale.preauthorized} \
-              -tags=${lib.escapeShellArg (lib.concatStringsSep "," cfg.tailscale.tags)} \
-              -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
-              -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
-              -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
-              -hostKey=''${CREDENTIALS_DIRECTORY}/privateHostKey \
-              -clientIdFile=''${CREDENTIALS_DIRECTORY}/clientId \
-              -clientSecretFile=''${CREDENTIALS_DIRECTORY}/clientSecret \
-              ${lib.escapeShellArgs cfg.ssh.commandLine}
+            ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
+               -tsnetVerbose=${lib.boolToString cfg.tailscale.tsnetVerbose} \
+               -preauthorized=${lib.boolToString cfg.tailscale.preauthorized} \
+               -tags=${lib.escapeShellArg (lib.concatStringsSep "," cfg.tailscale.tags)} \
+               -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
+               -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
+               -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
+               -hostKey=/etc/hoopsnake/ssh/host_key \
+               ${lib.escapeShellArgs cfg.ssh.commandLine} &
+            hoopsnakePid=$!
           '';
-
-          environment.HOME = "/tmp";
-          serviceConfig = {
-            Type = "simple";
-            KillMode = "process";
-            Restart = "on-failure";
-            EnvironmentFile = lib.mkIf (cfg.tailscale.environmentFile != null) "/etc/hoopsnake/tailscale/environment";
-            LoadCredential =
-              lib.concatMap (
-                credName:
-                  if (!cfg.systemd-credentials.${credName}.encrypted)
-                  then ["${credName}:/etc/hoopsnake/${credName}"]
-                  else []
-              )
-              fileCredentials;
-            LoadCredentialEncrypted =
-              lib.concatMap (
-                credName:
-                  if cfg.systemd-credentials.${credName}.encrypted
-                  then ["${credName}:/etc/hoopsnake/${credName}"]
-                  else []
-              )
-              fileCredentials;
-
-            SetCredential =
-              lib.concatMap (
-                credName:
-                  if (!cfg.systemd-credentials.${credName}.encrypted)
-                  then ["${credName}:${cfg.systemd-credentials.${credName}.text}"]
-                  else []
-              )
-              textCredentials;
-            SetCredentialEncrypted =
-              lib.concatMap (
-                credName:
-                  if cfg.systemd-credentials.${credName}.encrypted
-                  then ["${credName}:${cfg.systemd-credentials.${credName}.text}"]
-                  else []
-              )
-              textCredentials;
-          };
-        };
-        boot.initrd.secrets = lib.mkMerge [
-          {
-            "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
-          }
-          (lib.mkIf (cfg.tailscale.environmentFile != null) {"/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;})
-          (lib.mkIf cfg.includeSSLBundle {
-            "/etc/ssl/ca-bundle.crt" = config.environment.etc."ssl/certs/ca-bundle.crt".source;
-            "/etc/ssl/ca-certificates.crt" = config.environment.etc."ssl/certs/ca-certificates.crt".source;
-            "/etc/pki/tls/certs/ca-bundle.crt" = config.environment.etc."pki/tls/certs/ca-bundle.crt".source;
-            "/etc/ssl/trust-source" = config.environment.etc."ssl/trust-source".source;
-          })
-          (builtins.listToAttrs (builtins.map (credName: {
-              name = "/etc/hoopsnake/${credName}";
-              value = "${cfg.systemd-credentials.${credName}.file}";
+          boot.initrd.postMountCommands = ''
+              if [ -n "$hoopsnakePid" ]; then
+              kill "$hoopsnakePid"
+              ${
+              if cfg.tailscale.cleanup.exitTimeoutSec != null
+              then ''
+                timeToWait=${toString cfg.tailscale.cleanup.exitTimeoutSec}
+                while [ $timeToWait -gt 0 ] && ! kill -0 "$hoopsnakePid" 2>/dev/null ; do
+                  timeToWait=$((timeToWait-1))
+                  sleep 1
+                done
+              ''
+              else ""
+            }
+            fi
+          '';
+          boot.initrd.secrets = lib.mkMerge [
+            {
+              "/etc/hoopsnake/ssh/host_key" = cfg.ssh.privateHostKey;
+              "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
+            }
+            (lib.mkIf (cfg.tailscale.environmentFile != null) {
+              "/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;
             })
-            fileCredentials))
-        ];
-      }))
-    ]);
+            (lib.mkIf cfg.includeSSLBundle {
+              "/etc/ssl/ca-bundle.crt" = config.environment.etc."ssl/certs/ca-bundle.crt".source;
+              "/etc/ssl/ca-certificates.crt" = config.environment.etc."ssl/certs/ca-certificates.crt".source;
+              "/etc/pki/tls/certs/ca-bundle.crt" = config.environment.etc."pki/tls/certs/ca-bundle.crt".source;
+              "/etc/ssl/trust-source" = config.environment.etc."ssl/trust-source".source;
+            })
+          ];
+        })
+        (lib.mkIf config.boot.initrd.systemd.enable (
+          let
+            credentials = [
+              "privateHostKey"
+              "clientId"
+              "clientSecret"
+            ];
+            textCredentials =
+              lib.concatMap (
+                credName:
+                  if (cfg.systemd-credentials.${credName}.file == null)
+                  then [credName]
+                  else []
+              )
+              credentials;
+            fileCredentials =
+              lib.concatMap (
+                credName:
+                  if (cfg.systemd-credentials.${credName}.file != null)
+                  then [credName]
+                  else []
+              )
+              credentials;
+          in {
+            boot.initrd.systemd.storePaths = [
+              cfg.package
+              cfg.ssh.shell
+            ];
+            boot.initrd.systemd.services.hoopsnake = {
+              description = "Hoopsnake initrd ssh server";
+              wantedBy = ["initrd.target"];
+              wants = ["network-online.target"];
+              after = [
+                "network-online.target"
+                "initrd-nixos-copy-secrets.service"
+              ];
+              before = [
+                "shutdown.target"
+                "initrd-switch-root.target"
+              ];
+              conflicts = [
+                "shutdown.target"
+                "initrd-switch-root.target"
+              ];
+              unitConfig.DefaultDependencies = false;
+
+              script = ''
+                set -eu -x
+
+                exec ${lib.getExe cfg.package} -name ${lib.escapeShellArg cfg.tailscale.name} \
+                  -tsnetVerbose=${lib.boolToString cfg.tailscale.tsnetVerbose} \
+                  -preauthorized=${lib.boolToString cfg.tailscale.preauthorized} \
+                  -tags=${lib.escapeShellArg (lib.concatStringsSep "," cfg.tailscale.tags)} \
+                  -deleteExisting=${lib.boolToString cfg.tailscale.cleanup.deleteExisting} \
+                  -maxNodeAge=${lib.escapeShellArg cfg.tailscale.cleanup.maxNodeAge} \
+                  -authorizedKeys=/etc/hoopsnake/ssh/authorized_keys \
+                  -hostKey=''${CREDENTIALS_DIRECTORY}/privateHostKey \
+                  -clientIdFile=''${CREDENTIALS_DIRECTORY}/clientId \
+                  -clientSecretFile=''${CREDENTIALS_DIRECTORY}/clientSecret \
+                  ${lib.escapeShellArgs cfg.ssh.commandLine}
+              '';
+
+              environment.HOME = "/tmp";
+              serviceConfig = {
+                Type = "simple";
+                KillMode = "process";
+                Restart = "on-failure";
+                EnvironmentFile = lib.mkIf (
+                  cfg.tailscale.environmentFile != null
+                ) "/etc/hoopsnake/tailscale/environment";
+                LoadCredential =
+                  lib.concatMap (
+                    credName:
+                      if (!cfg.systemd-credentials.${credName}.encrypted)
+                      then ["${credName}:/etc/hoopsnake/${credName}"]
+                      else []
+                  )
+                  fileCredentials;
+                LoadCredentialEncrypted =
+                  lib.concatMap (
+                    credName:
+                      if cfg.systemd-credentials.${credName}.encrypted
+                      then ["${credName}:/etc/hoopsnake/${credName}"]
+                      else []
+                  )
+                  fileCredentials;
+
+                SetCredential =
+                  lib.concatMap (
+                    credName:
+                      if (!cfg.systemd-credentials.${credName}.encrypted)
+                      then ["${credName}:${cfg.systemd-credentials.${credName}.text}"]
+                      else []
+                  )
+                  textCredentials;
+                SetCredentialEncrypted =
+                  lib.concatMap (
+                    credName:
+                      if cfg.systemd-credentials.${credName}.encrypted
+                      then ["${credName}:${cfg.systemd-credentials.${credName}.text}"]
+                      else []
+                  )
+                  textCredentials;
+              };
+            };
+            boot.initrd.secrets = lib.mkMerge [
+              {
+                "/etc/hoopsnake/ssh/authorized_keys" = cfg.ssh.authorizedKeysFile;
+              }
+              (lib.mkIf (cfg.tailscale.environmentFile != null) {
+                "/etc/hoopsnake/tailscale/environment" = cfg.tailscale.environmentFile;
+              })
+              (lib.mkIf cfg.includeSSLBundle {
+                "/etc/ssl/ca-bundle.crt" = config.environment.etc."ssl/certs/ca-bundle.crt".source;
+                "/etc/ssl/ca-certificates.crt" = config.environment.etc."ssl/certs/ca-certificates.crt".source;
+                "/etc/pki/tls/certs/ca-bundle.crt" = config.environment.etc."pki/tls/certs/ca-bundle.crt".source;
+                "/etc/ssl/trust-source" = config.environment.etc."ssl/trust-source".source;
+              })
+              (builtins.listToAttrs (
+                builtins.map (credName: {
+                  name = "/etc/hoopsnake/${credName}";
+                  value = "${cfg.systemd-credentials.${credName}.file}";
+                })
+                fileCredentials
+              ))
+            ];
+          }
+        ))
+      ]
+    );
 }

--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -45,9 +45,14 @@
       };
       configFile = pkgs.writeText "headscale-setup-config.yaml" (builtins.toJSON config);
     in
-      pkgs.runCommand "setup-headscale" {
-        nativeBuildInputs = [pkgs.headscale pkgs.sqlite];
-      } ''
+      pkgs.runCommand "setup-headscale"
+      {
+        nativeBuildInputs = [
+          pkgs.headscale
+          pkgs.sqlite
+        ];
+      }
+      ''
         set -eux
 
         mkdir -p $out
@@ -145,7 +150,10 @@
         };
       };
       networking.firewall = {
-        allowedTCPPorts = [80 443];
+        allowedTCPPorts = [
+          80
+          443
+        ];
         allowedUDPPorts = [stunPort];
       };
       environment.systemPackages = [
@@ -188,84 +196,9 @@
     };
   in {
     checks =
-      if ! pkgs.lib.hasSuffix "linux" system
+      if !pkgs.lib.hasSuffix "linux" system
       then {}
       else {
-        hoopsnake-scripted = pkgs.testers.runNixOSTest {
-          name = "hoopsnake-scripted-initrd-stage1";
-          nodes = {
-            inherit headscale bob;
-            alice = {
-              lib,
-              config,
-              ...
-            }: {
-              imports = [bootloader self.nixosModules.default];
-              boot.initrd.preLVMCommands = ''
-                while ! [ -f /tmp/fnord ] ; do
-                  pgrep $hoopsnakePid
-                  sleep 1
-                done
-              '';
-
-              boot.initrd.network = {
-                hoopsnake = {
-                  enable = true;
-                  ssh = {
-                    authorizedKeysFile = "${clientKey}/client.pub";
-                    privateHostKey = "${hostkey}/hostkey";
-                    shell = lib.getExe (pkgs.writeShellApplication {
-                      name = "success";
-                      text = "touch /tmp/fnord";
-                    });
-                  };
-                  tailscale = {
-                    name = "alice-boot";
-                    tags = ["tag:hoopsnake"];
-                    environmentFile = "${headscaleAccess}/authkey-envfile";
-                    tsnetVerbose = true;
-                  };
-                };
-              };
-            };
-          };
-
-          testScript = ''
-            import time
-            import json
-
-            def wait_for_hoopsnake_registered(name):
-                "Poll until hoopsnake appears in the list of hosts, then return its IP."
-                while True:
-                    status = json.loads(bob.succeed("tailscale status --json --peers --self=false"))
-                    if status["Peer"] is not None:
-                      basic_entry = [elt["TailscaleIPs"][0] for _, elt in status["Peer"].items() if elt["HostName"] == name]
-                      if len(basic_entry) == 1:
-                          return basic_entry[0]
-                    time.sleep(1)
-
-
-            with subtest("Test setup"):
-                for node in [headscale, bob]:
-                    node.start()
-                headscale.wait_for_unit("headscale")
-                headscale.wait_for_open_port(${toString headscalePort})
-                headscale.wait_for_open_port(443)
-
-                # Import user & hoopsnake auth key
-                headscale.succeed("import-pregenerated-keys")
-                authkey = headscale.succeed("headscale preauthkeys -u 1 create --reusable")
-
-                # Connect peers
-                up_cmd = f"tailscale up --login-server 'https://headscale' --auth-key {authkey}"
-                bob.execute(up_cmd)
-
-            alice.start()
-            alice_ip = wait_for_hoopsnake_registered("alice-boot")
-            bob.succeed(f"ssh-to-alice {alice_ip}", timeout=90)
-            alice.wait_for_unit("multi-user.target", timeout=90)
-          '';
-        };
         hoopsnake-systemd = pkgs.testers.runNixOSTest {
           name = "hoopsnake-systemd-initrd-stage1";
           nodes = {
@@ -280,7 +213,10 @@
                 text = "touch /tmp/fnord";
               };
             in {
-              imports = [bootloader self.nixosModules.default];
+              imports = [
+                bootloader
+                self.nixosModules.default
+              ];
               testing.initrdBackdoor = true;
               boot.initrd.systemd = {
                 enable = true;
@@ -321,6 +257,7 @@
             def wait_for_hoopsnake_registered(name):
                 "Poll until hoopsnake appears in the list of hosts, then return its IP."
                 while True:
+                    bob.wait_until_succeeds(f"tailscale ping -c 1 {name}")
                     status = json.loads(bob.succeed("tailscale status --json --peers --self=false"))
                     if status["Peer"] is not None:
                       basic_entry = [elt["TailscaleIPs"][0] for _, elt in status["Peer"].items() if elt["HostName"] == name]
@@ -382,7 +319,9 @@
                 up_cmd = f"tailscale up --login-server 'https://headscale' --auth-key {authkey}"
                 bob.execute(up_cmd)
                 bob.execute(f"echo '{authkey}' > /tmp/clientId")
-            configtest_cmd = "systemd-run --wait --pipe --service-type=exec -E HOME=/tmp -p EnvironmentFile=${headscaleAccess}/authkey-envfile ${self.packages.${pkgs.stdenv.targetPlatform.system}.hoopsnake}/bin/hoopsnake -configtest -name bob /usr/bin/env"
+            configtest_cmd = "systemd-run --wait --pipe --service-type=exec -E HOME=/tmp -p EnvironmentFile=${headscaleAccess}/authkey-envfile ${
+              self.packages.${pkgs.stdenv.targetPlatform.system}.hoopsnake
+            }/bin/hoopsnake -configtest -name bob /usr/bin/env"
             bob.succeed(configtest_cmd)
           '';
         };


### PR DESCRIPTION
systemd initrd will be the default in the next nixos (and will hopefully be disabled soon), so let's disable tests for it now. Also, bump flake.lock so we get the latest go toolchain & can update the tailscale library.